### PR TITLE
Read from superclass when `@serialized_uploaders` not present

### DIFF
--- a/lib/carrierwave-serializable/orm/activerecord.rb
+++ b/lib/carrierwave-serializable/orm/activerecord.rb
@@ -6,9 +6,13 @@ module CarrierWave
   module ActiveRecord
     module Serializable
       def serialized_uploaders
-        @serialized_uploaders ||= {}
+        @serialized_uploaders ||= if superclass.respond_to?(:serialized_uploaders)
+                                    superclass.serialized_uploaders
+                                  else
+                                    {}
+                                  end
       end
-    
+
       def serialized_uploader?(column)
         attribute_name = serialized_uploaders[column].to_s
         serialized_uploaders.key?(column) && (serialized_attribute?(attribute_name) ||
@@ -34,7 +38,7 @@ module CarrierWave
       #
       def mount_uploader(column, uploader=nil, options={}, &block)
         super
-        
+
         serialize_to = options.delete :serialize_to
         if serialize_to
           serialization_column = options[:mount_on] || column


### PR DESCRIPTION
Hi @timsly, I have encountered the same problem @cserb appears to have solved in PR(#5) although I am not sure why he duplicated the data. In the event when serialised uploader is added to `hstore` where it previously did not exist, `ActiveModel::MissingAttributeError` is raised.

This PR address specific problem.