### PR TITLE
Fix writer

### DIFF
--- a/lib/carrierwave-serializable/orm/activerecord.rb
+++ b/lib/carrierwave-serializable/orm/activerecord.rb
@@ -53,8 +53,13 @@ module CarrierWave
         class_eval <<-RUBY, __FILE__, __LINE__+1
           def write_uploader(column, identifier)
             if self.class.serialized_uploader?(column)
-              serialized_field = self.send self.class.serialized_uploaders[column]
-              serialized_field[column.to_s] = identifier
+              serialized_field_name = self.class.serialized_uploaders[column].to_s
+
+              if serialized_field = self.send(serialized_field_name)
+                serialized_field[column.to_s] = identifier
+              else
+                self.send "#{serialized_field_name}=", column.to_s => identifier
+              end
             else
               write_attribute(column, identifier)
             end


### PR DESCRIPTION
It is possible that the serialized attribute will be nil instead of a hash. If that's the case, then 1.) the hash needs to be initialized and 2.) we must use the setter (=) method to actually write the attribute. It isn't enough to set a variable equal to a hash - that will never get persisted.