### PR TITLE
Escape string interpolation

### DIFF
--- a/lib/carrierwave-serializable/orm/activerecord.rb
+++ b/lib/carrierwave-serializable/orm/activerecord.rb
@@ -42,7 +42,7 @@ module CarrierWave
               if serialized_field = self.send(serialized_field_name)
                 serialized_field[column.to_s] = identifier
               else
-                self.send "#{serialized_field_name}=", column.to_s => identifier
+                self.send "\#{serialized_field_name}=", column.to_s => identifier
               end
             else
               write_attribute(column, identifier)


### PR DESCRIPTION
@timsly this is a fix for one of the fixes we made in reviewing one of my previous PRs. All of this code is is a giant heredoc, so its a string and needs to have the `#` escaped if we don't want interpolation to happen at the wrong time.

I believe that without this fix, the gem is completely unusable. 