### PR TITLE
Read from superclass

### DIFF
--- a/lib/carrierwave-serializable/orm/activerecord.rb
+++ b/lib/carrierwave-serializable/orm/activerecord.rb
@@ -6,7 +6,7 @@ module CarrierWave
   module ActiveRecord
     module Serializable
       def serialized_uploaders
-        @serialized_uploaders ||= {}
+        @serialized_uploaders ||= read_from_superclass? ? superclass.serialized_uploaders : {}
       end
 
       def serialized_uploader?(column)
@@ -59,6 +59,12 @@ module CarrierWave
           end
         RUBY
 
+      end
+
+      private
+
+      def read_from_superclass?
+        superclass != ::ActiveRecord::Base && superclass.respond_to?(:serialized_uploaders)
       end
     end # Serializable
   end # ActiveRecord


### PR DESCRIPTION
This makes carrierwave-serializable work with STI

It is a combination of @Krule's code from https://github.com/timsly/carrierwave-serializable/pull/11 and a fix of my own.

Without this, when I place a `mount_uploader` call in the parent class in an STI setup, the uploader is not made available on the child classes.

(Note that this includes my code from https://github.com/timsly/carrierwave-serializable/pull/14 as I can't get anything working without it.)